### PR TITLE
Update available space on root filesystem

### DIFF
--- a/packer/docker_instance.json
+++ b/packer/docker_instance.json
@@ -8,7 +8,12 @@
             "ssh_username": "ec2-user",
             "ami_name": "ue4-server-host-{{ timestamp }}",
             "access_key": "{{user `aws_access_key`}}",
-            "secret_key": "{{user `aws_secret_key`}}"
+            "secret_key": "{{user `aws_secret_key`}}",
+            "launch_block_device_mappings": [{
+                "device_name": "/dev/xvda",
+                "volume_size": 15,
+                "delete_on_termination": true
+            }]
         }
     ],
     "provisioners": [


### PR DESCRIPTION
Sets the available space on the root EBS drive to 15gb, up from the source AMI's 8gb which may be too small for the docker container to extract a built server. This gives extra headroom above whats needed.